### PR TITLE
#2 Fixed InvalidElasticIpID.Malformed issue

### DIFF
--- a/natgateway.tf
+++ b/natgateway.tf
@@ -1,5 +1,5 @@
 resource "aws_nat_gateway" "natgateway" {
-  allocation_id = "aws_eip.ip.id"
+  allocation_id = "aws_eip.eip.id"
   subnet_id     = "aws_subnet.publicsubnet.id"
   tags = {
     name = "prod nategatway"


### PR DESCRIPTION
Found the solution thanks to https://stackoverflow.com/questions/70360265/terraform-error-creating-nat-gateway-invalidelasticipid-malformed

But still had issues running the scripts. I got an error with editing route for nat.tf saying that the destination_cidr_block of "0.0.0.0/0" was already defined.

For anyone else looking for a Terraform VPC template, I used this with success: https://github.com/BetcyBabu/Terraform-VPC-sample